### PR TITLE
fix: fix nil pointer error with StatefulSet labels when set

### DIFF
--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ template "atlantis.fullname" . }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
-    {{ with .Values.statefulSet.labels }}
-    {{- toYaml .Values.statefulSet.labels | nindent 4 }}
+    {{- with .Values.statefulSet.labels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if or .Values.statefulSet.annotations .Values.extraAnnotations }}
   annotations:


### PR DESCRIPTION
## what

Fix nil pointer error with StatefulSet labels when set, introduced in #356.

## why

```
    [ERROR] templates/: template: atlantis/templates/statefulset.yaml:8:22: executing "atlantis/templates/statefulset.yaml" at <.Values.statefulSet.labels>: nil pointer evaluating interface {}.statefulSet
```

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

https://github.com/runatlantis/helm-charts/pull/356#discussion_r1516867355